### PR TITLE
Add support for external access via Google Colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,27 @@ python cogstudio.py
 ```
 
 That's all!
+
+
+# Using on Google Colab
+
+To run Cogstudio on Google Colab and allow external access, you can use the `--share` option. Follow these steps:
+
+1. Setup:
+
+```bash
+!git clone https://github.com/THUDM/CogVideo
+!git clone https://github.com/pinokiofactory/cogstudio.git
+!cp cogstudio/cogstudio.py CogVideo/inference/gradio_composite_demo
+%cd /content/CogVideo/inference/gradio_composite_demo
+!pip install -r requirements.txt
+!pip install moviepy==2.0.0.dev2
+```
+
+2. Run `cogstudio.py` with the `--share` option to generate a public link for external access:
+
+```bash
+!python cogstudio.py --share
+```
+
+This will provide a shareable Gradio link, allowing access to the application from outside Colab.

--- a/cogstudio.py
+++ b/cogstudio.py
@@ -34,6 +34,7 @@ import utils
 from rife_model import load_rife_model, rife_inference_with_latents
 from huggingface_hub import hf_hub_download, snapshot_download
 import gc
+import argparse
 
 pipe = None
 pipe_image = None
@@ -873,4 +874,9 @@ with gr.Blocks(fill_width=True, fill_height=True, css=css) as demo:
     demo.load(refresh_generated_videos, outputs=reel)
 
 if __name__ == "__main__":
-    demo.launch()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--share", action="store_true", help="Share the app on Gradio")
+
+    args = parser.parse_args()
+
+    demo.launch(share=args.share)


### PR DESCRIPTION
This PR introduces a new feature allowing users to run Cogstudio on Google Colab with external access using the `--share` option. When executed with this option, a shareable Gradio link is generated for public access.

Changes:

 - Added `--share` argument to enable external access when running `cogstudio.py`.
 - Updated README with instructions for running Cogstudio on Google Colab.

Due to Google Colab's dependencies, errors do appear on the Colab console when starting up, but I have confirmed that it can be used without any issues.

I would appreciate it if you could review this Pull Request.